### PR TITLE
Update copyright and contact info

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 locagent
+Copyright (c) 2025 LocAgent.dev
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -47,7 +47,4 @@ This project is licensed under the **MIT License**. See [LICENSE](LICENSE) for d
 
 ## Contact
 
-Maintained by **LocAgent**.  
-GitHub: [locagent/i18n-best-practices](https://github.com/locagent/i18n-best-practices)  
-Website: [https://locagent.dev](https://locagent.dev)
-Email: hi@locagent.dev
+Maintained by [LocAgent.dev](https://locagent.dev). Contact us at hi@locagent.dev

--- a/index.md
+++ b/index.md
@@ -66,7 +66,3 @@ Only fix i18n-related code, do not change anything else.
 
 ### 6. Missing Translation Keys
 - Scan for missing translation keys in resource files and suggest adding them to the appropriate locale files.
-
----
-
-*This guide is open source and free for personal, educational, and commercial use under the MIT License. [View and contribute on GitHub](https://github.com/locagent/i18n-best-practices/blob/main/index.md).*


### PR DESCRIPTION
Changed copyright holder to LocAgent.dev in LICENSE. Updated contact and maintainer information in README.md. Removed footer and GitHub link from index.md.